### PR TITLE
Add(scripts): Adding pipeline scripts for zfs-localpv related tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -310,6 +310,72 @@ TCID-LOCALPV-HOSTPATH-CREATE:
     - chmod 755 ./stages/functional/local-pv-hostpath/local-pv-hostpath
     - ./stages/functional/local-pv-hostpath/local-pv-hostpath
 
+TCID-ZFS-LOCALPV-PROVISIONER:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+    - ./stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+
+TCID-ZFSPV-CUSTOM-TOPOLOGY:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFSPV-custom-topology/ZFSPV-custom-topology
+    - ./stages/functional/ZFSPV-custom-topology/ZFSPV-custom-topology
+
+TCID-ZV-PROPERTY-MODIFY:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZV-property-modify/ZV-property-modify
+    - ./stages/functional/ZV-property-modify/ZV-property-modify
+
+TCID-ZV-PROPERTY-MODIFY-ext4:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZV-property-modify-ext4/ZV-property-modify-ext4
+    - ./stages/functional/ZV-property-modify-ext4/ZV-property-modify-ext4
+
+TCID-ZV-PROPERTY-MODIFY-xfs:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZV-property-modify-xfs/ZV-property-modify-xfs
+    - ./stages/functional/ZV-property-modify-xfs/ZV-property-modify-xfs
+
+TCID-ZFSPV-SNAPSHOT-CLONE:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFSPV-snapshot-clone/ZFSPV-snapshot-clone
+    - ./stages/functional/ZFSPV-snapshot-clone/ZFSPV-snapshot-clone
+
+TCID-ZFSPV-SNAPSHOT-CLONE-ext4:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
+    - ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
+
+TCID-ZFSPV-SNAPSHOT-CLONE-xfs:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+    - ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+
+TCID-ZFS-VOL-RESIZE:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFS-vol-resize/ZFS-vol-resize
+    - ./stages/functional/ZFS-vol-resize/ZFS-vol-resize
+
+TCID-ZFS-VOL-RESIZE-ext4:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
+    - ./stages/functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
+
+TCID-ZFS-VOL-RESIZE-xfs:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
+    - ./stages/functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
+
 # OpenEBS CHAOS Tests JOBS
 
 .chaos_test_template:

--- a/stages/functional/Jiva-App-Target-Affinity/app-target-affinity
+++ b/stages/functional/Jiva-App-Target-Affinity/app-target-affinity
@@ -208,7 +208,7 @@ rc_val=$(echo $?)
 
  # Update result of the test case in github mayadata-io/e2e-openshift repository.
 if [ "$rc_val" != "0" ]; then
-python3 utils/result/result_update.py $job_id FSJT 3-functional "Checking Application and target scheduled on same Node" Fail $pipeline_id "$current_time" $commit_id $gittoken
+python3 utils/result/result_update.py $job_id FSJT functional "Checking Application and target scheduled on same Node" Fail $pipeline_id "$current_time" $commit_id $gittoken
 exit 1;
 fi
 
@@ -256,7 +256,7 @@ cat deprovision_affinity_jiva.yml
 bash ../utils/litmus_job_runner label='app:busybox-deprovision-affinity-jiva' job=deprovision_affinity_jiva.yml
 cd ..
 bash utils/dump_cluster_state;
-bash utils/event_updater jobname:app-target-affinity-jiva  $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+bash utils/event_updater jobname:app-target-affinity-jiva $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 rc_val=$(echo $?)
 current_time=$(eval $time)
@@ -264,11 +264,11 @@ current_time=$(eval $time)
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 
 if [ "$rc_val" != "0" ]; then
-bash utils/e2e-cr-new jobname:app-target-affinity-jiva  jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
+bash utils/e2e-cr-new jobname:app-target-affinity-jiva jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
 exit 1;
 fi
 
-bash utils/e2e-cr-new jobname:app-target-affinity-jiva  jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
+bash utils/e2e-cr-new jobname:app-target-affinity-jiva jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:$testResult
 
 if [ "$rc_val" != "0" ]; then
 exit 1;

--- a/stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$ZFS_BRANCH'"' '"'$ZFS_DRIVER_IMAGE'"'
+
+}
+
+#######################################
+#    Deploy ZFS LocalPV provisioner   #
+#######################################
+
+run_job() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+zfs_branch=$(echo $4)
+zfs_driver_image=$(echo $5)
+releaseTag=$(echo $5 | cut -d ":" -f 2)
+echo "releaseTag=$releaseTag"
+
+time="date"
+current_time=$(eval $time)
+
+## Create the e2e-result-custom-resources for the jobs
+bash utils/e2e-cr-new jobname:zfspv-provisioner jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfspv-custom-topology jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfspv-snapshot-clone jobphase:Waiting
+bash utils/e2e-cr-new jobname:snap-clone-ext4 jobphase:Waiting
+bash utils/e2e-cr-new jobname:snap-clone-xfs jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfs-vol-resize jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfs-vol-resize-ext4 jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfs-vol-resize-xfs jobphase:Waiting
+bash utils/e2e-cr-new jobname:zv-property-modify jobphase:Waiting
+bash utils/e2e-cr-new jobname:zv-property-modify-ext4 jobphase:Waiting
+bash utils/e2e-cr-new jobname:zv-property-modify-xfs jobphase:Waiting
+bash utils/e2e-cr-new jobname:zfspv-provisioner jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for deploying ZFS LocalPV provisioner
+test_name=$(bash utils/generate_test_name testcase=zfspv-provisioner metadata="")
+echo $test_name
+
+# copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp providers/zfs-localpv-provisioner/run_litmus_test.yml zfs_pv_provisioner.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/g}' \
+-e "/name: ZFS_BRANCH/{n;s/.*/            value: ${zfs_branch}/g}" \
+-e "/name: ZFS_DRIVER_IMAGE/{n;s/.*/            value: ${zfs_driver_image}/g}" \
+-e '/name: OS_NAME/{n;s/.*/            value: centos7/g}' \
+-e '/name: ZPOOL_CREATION/{n;s/.*/            value: "false"/g}' \
+-e '/name: POOL_NAME/{n;s/.*/            value: zfs-test-pool/g}' \
+-e '/name: POOL_TYPE/{n;s/.*/            value: striped/g}' \
+-e '/name: ACTION/{n;s/.*/            value: provision/g}' \
+-e '/name: COMPRESSION/{n;s/.*/            value: "on"/g}' \
+-e '/name: DEDUP/{n;s/.*/            value: "on"/g}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/g}' \
+-e '/name: VOLBLOCKSIZE/{n;s/.*/            value: 4k/g}' \
+-e '/name: RECORDSIZE/{n;s/.*/            value: 4k/g}' zfs_pv_provisioner.yml
+
+cat zfs_pv_provisioner.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:openebs-zfspv-provision' job=zfs_pv_provisioner.yml
+## Get the cluster state Once the litmus jobs completed.
+cd ..
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-provisioner $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+#################
+## GET RESULT  ##
+#################
+
+rc_val=$(echo $?)
+
+source ~/.profile
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+
+current_time=$(eval $time)
+bash utils/e2e-cr-new jobname:zfspv-provisioner jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:$testResult
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+}
+
+if [ "$1" == "run_job" ];then
+  run_job $2 $3 $4 $5 $6
+else
+  connect_cluster
+fi
+

--- a/stages/functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
+++ b/stages/functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+csi_vol_resize_rc_val=1
+zv_properties_verify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFS-vol-resize-ext4/ZFS-vol-resize-ext4 run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zfs-vol-resize-ext4 jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfspv_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deploy-percona-ext4/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-ext4-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-ext4/g' deploy_percona_zfspv_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deploy_percona_zfspv_ext4.yml
+
+cat deploy_percona_zfspv_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deploy-percona-ext4' job=deploy_percona_zfspv_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+#############################
+#  ZVOL-properties-verify   #
+#############################
+
+zv_properties_verify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=zvol-properties-verify metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-properties-verify/run_litmus_test.yml zv_properties_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-ext4/g}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/g}' \
+-e 's/generateName: zv-properties-verify-/generateName: ext4-zv-properties-verify-/g' \
+-e 's/name: zv-properties-verify/name: zv-properties-verify-ext4/g' zv_properties_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_properties_ext4.yml
+
+cat zv_properties_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zv-properties-verify-ext4' job=zv_properties_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_properties_verify_rc_val=$(echo $?)
+if [ "$zv_properties_verify_rc_val" != "0" ]; then
+csi_vol_resize
+app_deprovision
+fi
+
+}
+
+#############################
+# CSI volume resize for ext4 #
+#############################
+
+csi_vol_resize() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=csi-volume-resize metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/csi-volume-resize/run_litmus_test.yml csi_vol_resize_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/g}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-ext4/g}' \
+-e 's/app: csi-vol-resize/app: csi-vol-resize-ext4/g' \
+-e '/name: PV_CAPACITY/{n;s/.*/            value: 5Gi/g}' \
+-e '/name: NEW_CAPACITY/{n;s/.*/            value: 10Gi/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-ext4/g}' csi_vol_resize_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' csi_vol_resize_ext4.yml
+
+cat csi_vol_resize_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:csi-vol-resize-ext4' job=csi_vol_resize_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+csi_vol_resize_rc_val=$(echo $?)
+if [ "$csi_vol_resize_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="ext4-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deprovision_percona_zfspv_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-ext4/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-ext4-dep-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-ext4/g' deprovision_percona_zfspv_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deprovision_percona_zfspv_ext4.yml           
+
+cat deprovision_percona_zfspv_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deprovision-percona-ext4' job=deprovision_percona_zfspv_ext4.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_properties_verify_rc_val" -eq "0" ] &&
+   [ "$csi_vol_resize_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_properties_verify
+  csi_vol_resize
+  app_deprovision
+else
+  connect_cluster
+fi
+

--- a/stages/functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
+++ b/stages/functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+csi_vol_resize_rc_val=1
+zv_properties_verify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFS-vol-resize-xfs/ZFS-vol-resize-xfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zfs-vol-resize-xfs jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfspv_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deploy-percona-xfs/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-xfs-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-xfs/g' deploy_percona_zfspv_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deploy_percona_zfspv_xfs.yml
+
+cat deploy_percona_zfspv_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deploy-percona-xfs' job=deploy_percona_zfspv_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+#############################
+#  ZVOL-properties-verify   #
+#############################
+
+zv_properties_verify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=zvol-properties-verify metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-properties-verify/run_litmus_test.yml zv_properties_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-xfs/g}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/g}' \
+-e 's/generateName: zv-properties-verify-/generateName: xfs-zv-properties-verify-/g' \
+-e 's/name: zv-properties-verify/name: zv-properties-verify-xfs/g' zv_properties_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_properties_xfs.yml
+
+cat zv_properties_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zv-properties-verify-xfs' job=zv_properties_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_properties_verify_rc_val=$(echo $?)
+if [ "$zv_properties_verify_rc_val" != "0" ]; then
+csi_vol_resize
+app_deprovision
+fi
+
+}
+
+#############################
+# CSI volume resize for xfs #
+#############################
+
+csi_vol_resize() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=csi-volume-resize metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/csi-volume-resize/run_litmus_test.yml csi_vol_resize_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/g}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-xfs/g}' \
+-e 's/app: csi-vol-resize/app: csi-vol-resize-xfs/g' \
+-e '/name: PV_CAPACITY/{n;s/.*/            value: 5Gi/g}' \
+-e '/name: NEW_CAPACITY/{n;s/.*/            value: 10Gi/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-xfs/g}' csi_vol_resize_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' csi_vol_resize_xfs.yml
+
+cat csi_vol_resize_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:csi-vol-resize-xfs' job=csi_vol_resize_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+csi_vol_resize_rc_val=$(echo $?)
+if [ "$csi_vol_resize_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="xfs-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deprovision_percona_zfspv_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-xfs/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-xfs-dep-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-xfs/g' deprovision_percona_zfspv_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deprovision_percona_zfspv_xfs.yml           
+
+cat deprovision_percona_zfspv_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deprovision-percona-xfs' job=deprovision_percona_zfspv_xfs.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_properties_verify_rc_val" -eq "0" ] &&
+   [ "$csi_vol_resize_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_properties_verify
+  csi_vol_resize
+  app_deprovision
+else
+  connect_cluster
+fi
+

--- a/stages/functional/ZFS-vol-resize/ZFS-vol-resize
+++ b/stages/functional/ZFS-vol-resize/ZFS-vol-resize
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+csi_vol_resize_rc_val=1
+zv_properties_verify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFS-vol-resize/ZFS-vol-resize run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zfs-vol-resize jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfspv.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deploy-percona-zfs/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfspv-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs/g' deploy_percona_zfspv.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deploy_percona_zfspv.yml
+
+cat deploy_percona_zfspv.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deploy-percona-zfs' job=deploy_percona_zfspv.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+#############################
+#  ZVOL-properties-verify   #
+#############################
+
+zv_properties_verify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs";test_name=$(bash utils/generate_test_name testcase=zvol-properties-verify metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-properties-verify/run_litmus_test.yml zv_properties_zfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs/g}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/g}' \
+-e 's/generateName: zv-properties-verify-/generateName: zfs-zv-properties-verify-/g' \
+-e 's/name: zv-properties-verify/name: zv-properties-verify-zfs/g' zv_properties_zfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_properties_zfs.yml
+
+cat zv_properties_zfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zv-properties-verify-zfs' job=zv_properties_zfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_properties_verify_rc_val=$(echo $?)
+if [ "$zv_properties_verify_rc_val" != "0" ]; then
+csi_vol_resize
+app_deprovision
+fi
+
+}
+
+#############################
+# CSI volume resize for zfs #
+#############################
+
+csi_vol_resize() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs";test_name=$(bash utils/generate_test_name testcase=csi-volume-resize metadata=${run_id})
+echo $test_name
+
+## copy the content of run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/csi-volume-resize/run_litmus_test.yml csi_vol_resize_zfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/g}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/g}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-zfs/g}' \
+-e 's/app: csi-vol-resize/app: csi-vol-resize-zfs/g' \
+-e '/name: PV_CAPACITY/{n;s/.*/            value: 5Gi/g}' \
+-e '/name: NEW_CAPACITY/{n;s/.*/            value: 10Gi/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs/g}' csi_vol_resize_zfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' csi_vol_resize_zfs.yml
+
+cat csi_vol_resize_zfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:csi-vol-resize-zfs' job=csi_vol_resize_zfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+csi_vol_resize_rc_val=$(echo $?)
+if [ "$csi_vol_resize_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="zfs-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml deprovision_percona_zfspv.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-zfs/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfspv-dep-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs/g' deprovision_percona_zfspv.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deprovision_percona_zfspv.yml           
+
+cat deprovision_percona_zfspv.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deprovision-percona-zfs' job=deprovision_percona_zfspv.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfs-vol-resize $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_properties_verify_rc_val" -eq "0" ] &&
+   [ "$csi_vol_resize_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfs-vol-resize jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_properties_verify
+  csi_vol_resize
+  app_deprovision
+else
+  connect_cluster
+fi
+

--- a/stages/functional/ZFSPV-custom-topology/ZFSPV-custom-topology
+++ b/stages/functional/ZFSPV-custom-topology/ZFSPV-custom-topology
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFSPV-custom-topology/ZFSPV-custom-topology run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#########################################
+#  Perform zfspv-custom-topology test   #
+#########################################
+
+run_job() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+
+time="date"
+current_time=$(eval $time)
+
+## Create the e2e-result-custom-resources for the jobs
+
+bash utils/pooling jobname:zfspv-provisioner
+bash utils/e2e-cr-new jobname:zfspv-custom-topology jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for performing zfspv-custom-topology support e2e-test
+test_name=$(bash utils/generate_test_name testcase=zfspv-custom-topology-test metadata="")
+echo $test_name
+
+# copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zfspv-custom-topology/run_litmus_test.yml run_custom_topology.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: topology/g}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: test=custom-topology/g}' \
+-e '/name: ZPOOL_NAME/{n;s/.*/            value: zfs-test-pool/g}' \
+-e '/name: FS_TYPE/{n;s/.*/            value: zfs/g}' \
+-e '/name: NODE_LABEL/{n;s/.*/            value: test=custom-topology/g}' run_custom_topology.yml
+
+cat run_custom_topology.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfspv-custom-topology' job=run_custom_topology.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-custom-topology $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+#################
+## GET RESULT  ##
+#################
+
+rc_val=$(echo $?)
+testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
+
+current_time=$(eval $time)
+bash utils/e2e-cr-new jobname:zfspv-custom-topology jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:$testResult
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+}
+
+if [ "$1" == "run_job" ];then
+  run_job $2 $3 $4
+else
+  connect_cluster
+fi
+

--- a/stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
+++ b/stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
@@ -1,0 +1,390 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_ext4_rc_val=1
+app_loadgen_ext4_rc_val=1
+zfspv_snapshot_ext4_rc_val=1
+zfspv_clone_ext4_rc_val=1
+zfspv_clone_ext4_deprovision_rc_val=1
+zfspv_snapshot_ext4_deprovision_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4 run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+###########################################################
+# Deploy percona application on ZFSPV when fstype is ext4 #
+###########################################################
+
+app_deploy_ext4() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:snap-clone-ext4 jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4-snap-clone";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of deployers run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_ext4_snap_clone.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: snap-clone-ext4/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-ext4-snap-clone-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: snap-clone-ext4/g' percona_ext4_snap_clone.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_ext4_snap_clone.yml
+
+cat percona_ext4_snap_clone.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:snap-clone-ext4' job=percona_ext4_snap_clone.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_ext4_rc_val=$(echo $?)
+if [ "$app_deploy_ext4_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+###################################
+# Loadgen on Percona application  #
+###################################
+
+app_loadgen_ext4() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="ext4-snap-clone";test_name=$(bash utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of workload run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/workload/run_litmus_test.yml loadgen_ext4_snap_clone.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/loadgen: percona-loadjob/loadgen: snap-clone-ext4/g' \
+-e 's/generateName: percona-loadgen-/generateName: percona-loadgen-ext4-snap-clone-/g' \
+-e 's/value: app-percona-ns/value: snap-clone-ext4/g' loadgen_ext4_snap_clone.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' loadgen_ext4_snap_clone.yml
+
+cat loadgen_ext4_snap_clone.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='loadgen:snap-clone-ext4' job=loadgen_ext4_snap_clone.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_loadgen_ext4_rc_val=$(echo $?)
+if [ "$app_loadgen_ext4_rc_val" != "0" ]; then
+app_deprovision_ext4
+fi
+
+}
+
+##############################
+# Create zfspv-snapshot-ext4 #
+##############################
+
+zfspv_snapshot_ext4() { 
+  
+## Generate test name for running litmusbook for creating zfspv snapshot
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml snap_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: snapshot-zfspv-ext4/g' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-ext4/g' \
+-e 's/name: zfspv-snapshot/name: snapshot-ext4/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-ext4/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-ext4/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' snap_ext4.yml
+
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: snap_clone_ext4
+' snap_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' snap_ext4.yml
+
+cat snap_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:snapshot-ext4' job=snap_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_ext4_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_ext4_rc_val" != "0" ]; then
+app_deprovision_ext4
+fi
+
+}
+
+###########################
+# create zfspv-clone-ext4 #
+###########################
+
+zfspv_clone_ext4() {
+
+## Generate the test name to run litmusbook for creating zfspv-clone
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml clone_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: clone-zfspv-ext4/g' \
+-e 's/name: zfspv-clone/name: clone-zfspv-ext4/g' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-ext4/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-ext4/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-ext4/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-ext4/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' clone_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' clone_ext4.yml
+
+cat clone_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:clone-zfspv-ext4' job=clone_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_ext4_rc_val=$(echo $?)
+if [ "$zfspv_clone_ext4_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision_ext4
+app_deprovision_ext4
+fi
+
+}
+
+################################
+# Deprovision zfspv-clone-ext4 #
+################################
+
+zfspv_clone_ext4_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv clone
+run_id="ext4-deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml clone_ext4_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: clone-ext4-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-clone/  name: clone-ext4-deprovision/g}' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-ext4/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-ext4/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-ext4/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-ext4/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' clone_ext4_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' clone_ext4_deprovision.yml
+
+cat clone_ext4_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:clone-ext4-deprovision' job=clone_ext4_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_ext4_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_clone_ext4_deprovision_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision_ext4
+app_deprovision_ext4
+fi
+
+}
+
+###################################
+# Deprovision zfspv-snapshot-ext4 #
+###################################
+
+zfspv_snapshot_ext4_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv-snapshot
+run_id="ext4-deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of provisioner run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml snap_ext4_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: snap-ext4-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-snapshot/  name: snap-ext4-deprovision/g}' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-ext4/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-ext4/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-ext4/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' snap_ext4_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' snap_ext4_deprovision.yml
+
+cat snap_ext4_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:snap-ext4-deprovision' job=snap_ext4_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_ext4_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_ext4_deprovision_rc_val" != "0" ]; then
+app_deprovision_ext4
+fi
+
+}
+
+###########################
+# Deprovision Application #
+###########################
+
+app_deprovision_ext4() {
+  
+## Generate test name to run litmusbook for deprovisioning the percona application
+run_id="ext4-snap-clone-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_ext4_snap_clone_dep.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: dep-snap-clone-ext4/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-snap-clone-ext4-dep-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: snap-clone-ext4/g' percona_ext4_snap_clone_dep.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_ext4_snap_clone_dep.yml
+
+cat percona_ext4_snap_clone_dep.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:dep-snap-clone-ext4' job=percona_ext4_snap_clone_dep.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_ext4_rc_val=$(echo $?)
+
+if [ "$app_deprovision_ext4_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_ext4_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_ext4_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_ext4_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_ext4_rc_val" -eq "0" ] &&
+   [ "$app_loadgen_ext4_rc_val" -eq "0" ] &&
+   [ "$app_deploy_ext4_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:snap-clone-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:snap-clone-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+
+if [ "$1" == "run_job" ];then
+  app_deploy_ext4 $2 $3 $4 $5
+  app_loadgen_ext4
+  zfspv_snapshot_ext4
+  zfspv_clone_ext4
+  zfspv_clone_ext4_deprovision
+  zfspv_snapshot_ext4_deprovision
+  app_deprovision_ext4
+else
+  connect_cluster
+fi

--- a/stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+++ b/stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
@@ -1,0 +1,390 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_xfs_rc_val=1
+app_loadgen_xfs_rc_val=1
+zfspv_snapshot_xfs_rc_val=1
+zfspv_clone_xfs_rc_val=1
+zfspv_clone_xfs_deprovision_rc_val=1
+zfspv_snapshot_xfs_deprovision_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+###########################################################
+# Deploy percona application on ZFSPV when fstype is xfs #
+###########################################################
+
+app_deploy_xfs() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:snap-clone-xfs jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs-snap-clone";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of deployers run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_xfs_snap_clone.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: snap-clone-xfs/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-xfs-snap-clone-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: snap-clone-xfs/g' percona_xfs_snap_clone.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_xfs_snap_clone.yml
+
+cat percona_xfs_snap_clone.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:snap-clone-xfs' job=percona_xfs_snap_clone.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_xfs_rc_val=$(echo $?)
+if [ "$app_deploy_xfs_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+###################################
+# Loadgen on Percona application  #
+###################################
+
+app_loadgen_xfs() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="xfs-snap-clone";test_name=$(bash utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of workload run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/workload/run_litmus_test.yml loadgen_xfs_snap_clone.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/loadgen: percona-loadjob/loadgen: snap-clone-xfs/g' \
+-e 's/generateName: percona-loadgen-/generateName: percona-loadgen-xfs-snap-clone-/g' \
+-e 's/value: app-percona-ns/value: snap-clone-xfs/g' loadgen_xfs_snap_clone.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' loadgen_xfs_snap_clone.yml
+
+cat loadgen_xfs_snap_clone.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='loadgen:snap-clone-xfs' job=loadgen_xfs_snap_clone.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_loadgen_xfs_rc_val=$(echo $?)
+if [ "$app_loadgen_xfs_rc_val" != "0" ]; then
+app_deprovision_xfs
+fi
+
+}
+
+##############################
+# Create zfspv-snapshot-xfs #
+##############################
+
+zfspv_snapshot_xfs() { 
+  
+## Generate test name for running litmusbook for creating zfspv snapshot
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml snap_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: snapshot-zfspv-xfs/g' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-xfs/g' \
+-e 's/name: zfspv-snapshot/name: snapshot-xfs/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-xfs/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-xfs/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' snap_xfs.yml
+
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: snap_clone_xfs
+' snap_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' snap_xfs.yml
+
+cat snap_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:snapshot-xfs' job=snap_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_xfs_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_xfs_rc_val" != "0" ]; then
+app_deprovision_xfs
+fi
+
+}
+
+###########################
+# create zfspv-clone-xfs #
+###########################
+
+zfspv_clone_xfs() {
+
+## Generate the test name to run litmusbook for creating zfspv-clone
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml clone_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: clone-zfspv-xfs/g' \
+-e 's/name: zfspv-clone/name: clone-zfspv-xfs/g' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-xfs/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-xfs/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-xfs/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-xfs/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' clone_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' clone_xfs.yml
+
+cat clone_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:clone-zfspv-xfs' job=clone_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_xfs_rc_val=$(echo $?)
+if [ "$zfspv_clone_xfs_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision_xfs
+app_deprovision_xfs
+fi
+
+}
+
+################################
+# Deprovision zfspv-clone-xfs #
+################################
+
+zfspv_clone_xfs_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv clone
+run_id="xfs-deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml clone_xfs_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: clone-xfs-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-clone/  name: clone-xfs-deprovision/g}' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-xfs/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-xfs/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-xfs/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-xfs/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' clone_xfs_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' clone_xfs_deprovision.yml
+
+cat clone_xfs_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:clone-xfs-deprovision' job=clone_xfs_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_xfs_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_clone_xfs_deprovision_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision_xfs
+app_deprovision_xfs
+fi
+
+}
+
+###################################
+# Deprovision zfspv-snapshot-xfs #
+###################################
+
+zfspv_snapshot_xfs_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv-snapshot
+run_id="xfs-deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of provisioner run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml snap_xfs_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: snap-xfs-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-snapshot/  name: snap-xfs-deprovision/g}' \
+-e 's/name: zfspv-snapshot-clone/name: snap-clone-xfs/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: snap-clone-xfs/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: snapshot-xfs/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' snap_xfs_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' snap_xfs_deprovision.yml
+
+cat snap_xfs_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:snap-xfs-deprovision' job=snap_xfs_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_xfs_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_xfs_deprovision_rc_val" != "0" ]; then
+app_deprovision_xfs
+fi
+
+}
+
+###########################
+# Deprovision Application #
+###########################
+
+app_deprovision_xfs() {
+  
+## Generate test name to run litmusbook for deprovisioning the percona application
+run_id="xfs-snap-clone-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_xfs_snap_clone_dep.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: dep-snap-clone-xfs/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-snap-clone-xfs-dep-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: snap-clone-xfs/g' percona_xfs_snap_clone_dep.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_xfs_snap_clone_dep.yml
+
+cat percona_xfs_snap_clone_dep.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:dep-snap-clone-xfs' job=percona_xfs_snap_clone_dep.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:snap-clone-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_xfs_rc_val=$(echo $?)
+
+if [ "$app_deprovision_xfs_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_xfs_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_xfs_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_xfs_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_xfs_rc_val" -eq "0" ] &&
+   [ "$app_loadgen_xfs_rc_val" -eq "0" ] &&
+   [ "$app_deploy_xfs_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:snap-clone-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:snap-clone-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+
+if [ "$1" == "run_job" ];then
+  app_deploy_xfs $2 $3 $4 $5
+  app_loadgen_xfs
+  zfspv_snapshot_xfs
+  zfspv_clone_xfs
+  zfspv_clone_xfs_deprovision
+  zfspv_snapshot_xfs_deprovision
+  app_deprovision_xfs
+else
+  connect_cluster
+fi

--- a/stages/functional/ZFSPV-snapshot-clone/ZFSPV-snapshot-clone
+++ b/stages/functional/ZFSPV-snapshot-clone/ZFSPV-snapshot-clone
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+app_loadgen_rc_val=1
+zfspv_snapshot_rc_val=1
+zfspv_clone_rc_val=1
+zfspv_clone_deprovision_rc_val=1
+zfspv_snapshot_deprovision_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZFSPV-snapshot-clone/ZFSPV-snapshot-clone run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zfspv-snapshot-clone jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs-snap";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of deployers run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml deploy_percona_zfssnap.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deploy-percona-zfs-snap/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfssnap-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' deploy_percona_zfssnap.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' deploy_percona_zfssnap.yml
+
+cat deploy_percona_zfssnap.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deploy-percona-zfs-snap' job=deploy_percona_zfssnap.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+###################################
+# Loadgen on Percona application  #
+###################################
+
+app_loadgen() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="zfs-snap";test_name=$(bash utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of workload run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/workload/run_litmus_test.yml loadgen_percona_zfssnap.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/loadgen: percona-loadjob/loadgen: percona-loadjob-zfs-snap/g' \
+-e 's/generateName: percona-loadgen-/generateName: percona-loadgen-zfs-snap-/g' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' loadgen_percona_zfssnap.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' loadgen_percona_zfssnap.yml
+
+cat loadgen_percona_zfssnap.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='loadgen:percona-loadjob-zfs-snap' job=loadgen_percona_zfssnap.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_loadgen_rc_val=$(echo $?)
+if [ "$app_loadgen_rc_val" != "0" ]; then
+app_deploy
+fi
+
+}
+
+#########################
+# Create zfspv-snapshot #
+#########################
+
+zfspv_snapshot() { 
+  
+## Generate test name for running litmusbook for creating zfspv snapshot
+test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata="")
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_test.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_snap_test.yml
+
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: zfs_snap
+' zfs_snap_test.yml
+
+cat zfs_snap_test.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfspv-snapshot' job=zfs_snap_test.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+######################
+# create zfspv-clone #
+######################
+
+zfspv_clone() {
+
+## Generate the test name to run litmusbook for creating zfspv-clone
+test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata="")
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_test.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-zfs/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_clone_test.yml
+
+cat zfs_clone_test.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfspv-clone' job=zfs_clone_test.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_rc_val=$(echo $?)
+
+if [ "$zfspv_clone_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision
+app_deprovision
+fi
+
+}
+
+###########################
+# Deprovision zfspv-clone #
+###########################
+
+zfspv_clone_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv clone
+run_id="deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-clone metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-clone/run_litmus_test.yml zfs_clone_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-clone-/generateName: zfspv-clone-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-clone/  name: zfspv-clone-deprovision/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc-zfs/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: CLONED_PVC_NAME/{n;s/.*/            value: clone-pvc/}' \
+-e '/name: CLONE_PVC_SIZE/{n;s/.*/            value: 5Gi/}' \
+-e '/name: APP_NAME/{n;s/.*/            value: percona/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: percona-clone/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_clone_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zfs_clone_deprovision.yml
+
+cat zfs_clone_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfspv-clone-deprovision' job=zfs_clone_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_clone_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_clone_deprovision_rc_val" != "0" ]; then
+zfspv_snapshot_deprovision
+app_deprovision
+fi
+
+}
+
+##############################
+# Deprovision zfspv-snapshot #
+##############################
+
+zfspv_snapshot_deprovision() {
+
+## Generate test name to run litmusbook for deprovisioning the zfspv-snapshot
+run_id="deprovision";test_name=$(bash utils/generate_test_name testcase=zfspv-snapshot metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of provisioner run_litmus_test.yml into a different file to update the test specific parameters.
+cp experiments/functional/zfs-LocalPV/zfspv-snapshot/run_litmus_test.yml zfs_snap_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zfspv-snapshot-/generateName: zfspv-snapshot-deprovision-/g' \
+-e '/labels:/{n;s/  name: zfspv-snapshot/  name: zfspv-snapshot-deprovision/g}' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-snap/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: SNAPSHOT_CLASS/{n;s/.*/            value: zfs-snapshot-class/}' \
+-e '/name: SNAPSHOT_NAME/{n;s/.*/            value: zfs-snapshot/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: ACTION/{n;s/.*/            value: deprovision/}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' zfs_snap_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zfs_snap_deprovision.yml
+
+cat zfs_snap_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfspv-snapshot-deprovision' job=zfs_snap_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zfspv_snapshot_deprovision_rc_val=$(echo $?)
+if [ "$zfspv_snapshot_deprovision_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+##########################
+# Deprovision Application#
+##########################
+
+app_deprovision() {
+  
+## Generate test name to run litmusbook for deprovisioning the percona application
+run_id="snap-deprovision";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+cd e2e-tests
+
+# copy the content of run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-zfs-snap/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-zfssnap-deprovision-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-snap/g' percona_deprovision.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision.yml
+
+cat percona_deprovision.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:deprovision-percona-zfs-snap' job=percona_deprovision.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zfspv-snapshot-clone $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_deprovision_rc_val" -eq "0" ] &&
+   [ "$zfspv_clone_rc_val" -eq "0" ] &&
+   [ "$zfspv_snapshot_rc_val" -eq "0" ] &&
+   [ "$app_loadgen_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfspv-snapshot-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zfspv-snapshot-clone jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4 $5
+  app_loadgen
+  zfspv_snapshot
+  zfspv_clone
+  zfspv_clone_deprovision
+  zfspv_snapshot_deprovision
+  app_deprovision
+else
+  connect_cluster
+fi

--- a/stages/functional/ZV-property-modify-ext4/ZV-property-modify-ext4
+++ b/stages/functional/ZV-property-modify-ext4/ZV-property-modify-ext4
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+zv_property_modify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZV-property-modify-ext4/ZV-property-modify-ext4 run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zv-property-modify-ext4 jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deploy_ext4_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deploy-ext4-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deploy-ext4-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-ext4-modify/g' percona_deploy_ext4_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deploy_ext4_property_modify.yml
+
+cat percona_deploy_ext4_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deploy-ext4-property-modify' job=percona_deploy_ext4_property_modify.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="ext4";test_name=$(bash utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-property-runtime-modify/run_litmus_test.yml zv_property_runtime_modify_ext4.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zv-property-runtime-modify-/generateName: ext4-zv-property-runtime-modify/g' \
+-e 's/name: zv-property-runtime-modify/name: ext4-zv-property-runtime-modify/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-ext4-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: NEW_COMPRESSION_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: NEW_DEDUP_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: ZPOOL_NAME/{n;s/.*/            value: zfs-test-pool/}' zv_property_runtime_modify_ext4.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_property_runtime_modify_ext4.yml
+
+cat zv_property_runtime_modify_ext4.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:ext4-zv-property-runtime-modify' job=zv_property_runtime_modify_ext4.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_property_modify_rc_val=$(echo $?)
+if [ "$zv_property_modify_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="deprovision-ext4-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision_ext4_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deprovision-ext4-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deprovision-ext4-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-ext4/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-ext4-modify/g' percona_deprovision_ext4_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision_ext4_property_modify.yml           
+
+cat percona_deprovision_ext4_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deprovision-ext4-property-modify' job=percona_deprovision_ext4_property_modify.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-ext4 $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify-ext4 jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_property_modify
+  app_deprovision
+else
+  connect_cluster
+fi

--- a/stages/functional/ZV-property-modify-xfs/ZV-property-modify-xfs
+++ b/stages/functional/ZV-property-modify-xfs/ZV-property-modify-xfs
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+zv_property_modify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZV-property-modify-xfs/ZV-property-modify-xfs run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zv-property-modify-xfs jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deploy_xfs_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deploy-xfs-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deploy-xfs-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-xfs-modify/g' percona_deploy_xfs_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deploy_xfs_property_modify.yml
+
+cat percona_deploy_xfs_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deploy-xfs-property-modify' job=percona_deploy_xfs_property_modify.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="xfs";test_name=$(bash utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-property-runtime-modify/run_litmus_test.yml zv_property_runtime_modify_xfs.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zv-property-runtime-modify-/generateName: xfs-zv-property-runtime-modify/g' \
+-e 's/name: zv-property-runtime-modify/name: xfs-zv-property-runtime-modify/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-xfs-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: NEW_COMPRESSION_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: NEW_DEDUP_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: ZPOOL_NAME/{n;s/.*/            value: zfs-test-pool/}' zv_property_runtime_modify_xfs.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_property_runtime_modify_xfs.yml
+
+cat zv_property_runtime_modify_xfs.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:xfs-zv-property-runtime-modify' job=zv_property_runtime_modify_xfs.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_property_modify_rc_val=$(echo $?)
+if [ "$zv_property_modify_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="deprovision-xfs-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision_xfs_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deprovision-xfs-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deprovision-xfs-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-xfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-xfs-modify/g' percona_deprovision_xfs_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision_xfs_property_modify.yml           
+
+cat percona_deprovision_xfs_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deprovision-xfs-property-modify' job=percona_deprovision_xfs_property_modify.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify-xfs $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify-xfs jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_property_modify
+  app_deprovision
+else
+  connect_cluster
+fi

--- a/stages/functional/ZV-property-modify/ZV-property-modify
+++ b/stages/functional/ZV-property-modify/ZV-property-modify
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+## Define and initialize test-result specific variables.
+app_deploy_rc_val=1
+zv_property_modify_rc_val=1
+
+## SSH into the cluster to run the kubernetes jobs for the experiments
+connect_cluster() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port -o LogLevel=ERROR 'cd oep-e2e-konvoy && bash stages/functional/ZV-property-modify/ZV-property-modify run_job '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+
+}
+
+#######################################
+# Deploy percona application on ZFSPV #
+#######################################
+
+app_deploy() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+source ~/.profile
+
+time="date"
+current_time=$(eval $time)
+
+## Pooling over the previous job to wait for its completion
+bash utils/pooling jobname:zfspv-custom-topology
+bash utils/e2e-cr-new jobname:zv-property-modify jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deploy_zfs_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deploy-zfs-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deploy-zfs-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-modify/g' percona_deploy_zfs_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deploy_zfs_property_modify.yml
+
+cat percona_deploy_zfs_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deploy-zfs-property-modify' job=percona_deploy_zfs_property_modify.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deploy_rc_val=$(echo $?)
+if [ "$app_deploy_rc_val" != "0" ]; then
+exit 1;
+fi
+
+}
+
+######################
+# ZV property modify #
+######################
+
+zv_property_modify() {
+
+## Generate the test name for running the litmusbook for percona deployment
+run_id="zfs";test_name=$(bash utils/generate_test_name testcase=zvol-property-runtime-modify metadata=${run_id})
+echo $test_name
+
+## copy the content of provisioner run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp experiments/functional/zfs-LocalPV/zv-property-runtime-modify/run_litmus_test.yml zv_property_runtime_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/generateName: zv-property-runtime-modify-/generateName: zfs-zv-property-runtime-modify/g' \
+-e 's/name: zv-property-runtime-modify/name: zfs-zv-property-runtime-modify/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: percona-zfs-modify/}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: name=percona/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: APP_PVC/{n;s/.*/            value: percona-mysql-claim/}' \
+-e '/name: OPERATOR_NAMESPACE/{n;s/.*/            value: openebs/}' \
+-e '/name: NEW_COMPRESSION_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: NEW_DEDUP_PARAMETER/{n;s/.*/            value: "on"/}' \
+-e '/name: ZPOOL_NAME/{n;s/.*/            value: zfs-test-pool/}' zv_property_runtime_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' zv_property_runtime_modify.yml
+
+cat zv_property_runtime_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='name:zfs-zv-property-runtime-modify' job=zv_property_runtime_modify.yml
+## Get the cluster state Once the litmus jobs completed.
+bash ../utils/dump_cluster_state;
+cd ..
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+zv_property_modify_rc_val=$(echo $?)
+if [ "$zv_property_modify_rc_val" != "0" ]; then
+app_deprovision
+fi
+
+}
+
+#######################################
+#   Deprovision percona application   #
+#######################################
+
+app_deprovision() {
+
+## Generate test name for running litmusbook for generate load on application
+run_id="deprovision-zfs-property-modify";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+# copy the content of workload run_litmus_test.yml into a temporary file to update the test specific parameters.
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision_zfs_property_modify.yml
+
+# Modify test specific values in runner file using sed command
+sed -i -e 's/app: percona-deployment/app: percona-deprovision-zfs-property-modify/g' \
+-e 's/generateName: litmus-percona-/generateName: percona-deprovision-zfs-property-modify-/g' \
+-e 's/value: openebs-standard/value: zfs-sc-zfs/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e '/name: TARGET_AFFINITY_CHECK/{n;s/value: enable/value: disable/g}' \
+-e 's/value: app-percona-ns/value: percona-zfs-modify/g' percona_deprovision_zfs_property_modify.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision_zfs_property_modify.yml           
+
+cat percona_deprovision_zfs_property_modify.yml
+
+## Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='app:percona-deprovision-zfs-property-modify' job=percona_deprovision_zfs_property_modify.yml
+cd ..
+## Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+## Update the e2e event for the job.
+bash utils/event_updater jobname:zv-property-modify $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+app_deprovision_rc_val=$(echo $?)
+
+if [ "$app_deprovision_rc_val" -eq "0" ] &&
+   [ "$zv_property_modify_rc_val" -eq "0" ] &&
+   [ "$app_deploy_rc_val" -eq "0" ]; then
+
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+
+else
+## Update the e2e-result-custom-resources for the job
+bash utils/e2e-cr-new jobname:zv-property-modify jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+exit 1;
+fi
+
+}
+
+if [ "$1" == "run_job" ];then
+  app_deploy $2 $3 $4
+  zv_property_modify
+  app_deprovision
+else
+  connect_cluster
+fi


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

This PR fixes issue: #https://github.com/mayadata-io/oep-e2e/issues/732

- Adding pipeline scripts for zfs-localpv related test-cases.
- Sequence of the Jobs will be
   zfspv-provisionier ==> zfspv-custom-topology ==> Rest of the cases in parallel
And this whole sequence will be parallel to all jobs which are already running in functional stage.
 