### PR TITLE
add(script): adding pipeline script for local provisioning on selected device test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -354,6 +354,13 @@ TCID-LOCALPV-RANDOM-DEVICE-CREATE:
     - chmod 755 ./stages/functional/local-pv-device/local-pv-device
     - ./stages/functional/local-pv-device/local-pv-device
 
+TCID-LOCALPV-SELECTED-DEVICE-CREATE:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
+    - ./stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
+    
+
 TCID-LOCALPV-HOSTPATH-CREATE:
   extends: .func_test_template
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,7 +360,6 @@ TCID-LOCALPV-SELECTED-DEVICE-CREATE:
     - chmod 755 ./stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
     - ./stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
     
-
 TCID-LOCALPV-HOSTPATH-CREATE:
   extends: .func_test_template
   script:

--- a/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
+++ b/stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/functional/localpv-provisioning-selected-device/localpv-provisioning-selected-device node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+releaseTag=$(echo $4)
+
+time="date"
+current_time=$(eval $time)
+
+present_dir=$(pwd)
+echo $present_dir
+
+bash utils/e2e-cr-new jobname:localpv-provisioning-selected-device jobphase:Waiting
+bash utils/e2e-cr-new jobname:localpv-provisioning-selected-device jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+
+##########################
+#  positive test case    #
+##########################
+
+echo "*******LocalPV-provisioning on selected device positive test-case********"
+
+run_id="positive";test_name=$(bash utils/generate_test_name testcase=localpv-selected-device metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+cp experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml localpv_selected_device_positive.yml
+
+sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
+-e 's/app: localpv-selected-device/app: localpv-selected-device-positive/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: localpv-selected-device-positive/g}' \
+-e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
+-e '/name: TEST_CASE_TYPE/{n;s/.*/            value: positive/g}' localpv_selected_device_positive.yml
+
+cat localpv_selected_device_positive.yml
+
+bash ../utils/litmus_job_runner label='app:localpv-selected-device-positive' job=localpv_selected_device_positive.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:localpv-provisioning-selected-device $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+##########################
+#  negative test case    #
+##########################
+
+echo "*******LocalPV-provisioning on selected device negative test-case********"
+
+run_id="negative";test_name=$(bash utils/generate_test_name testcase=localpv-selected-device metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+cp experiments/functional/localpv/localpv-provisioning-selected-device/run_litmus_test.yml localpv_selected_device_negative.yml
+
+sed -i -e '/name: OPERATOR_NS/{n;s/.*/            value: openebs/g}' \
+-e 's/app: localpv-selected-device/app: localpv-selected-device-negative/g' \
+-e '/name: APP_NAMESPACE/{n;s/.*/            value: localpv-selected-device-negative/g}' \
+-e '/name: PVC/{n;s/.*/            value: localpv-selected-device-pvc/g}' \
+-e '/name: TEST_CASE_TYPE/{n;s/.*/            value: negative/g}' localpv_selected_device_negative.yml
+
+cat localpv_selected_device_negative.yml
+
+bash ../utils/litmus_job_runner label='app:localpv-selected-device-negative' job=localpv_selected_device_negative.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:localpv-provisioning-selected-device $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+bash utils/e2e-cr-new jobname:local-pv-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+exit 1;
+fi
+
+bash utils/e2e-cr-new jobname:local-pv-device jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4 $5
+else
+  pod
+fi

--- a/stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP
+++ b/stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP
@@ -2,7 +2,7 @@
 
 pod() {
   echo "*************Deploying Director On-Prem*************"
-  sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP node '"'$GITHUB_USERNAME'"' '"'$GITHUB_PASSWORD'"' '"'$RELEASE_USERNAME'"' '"'$RELEASE_PASSWORD'"' '"'$RELEASE'"' '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"'' '"'$WAIT'"'
+  sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP node '"'$GITHUB_USERNAME'"' '"'$GITHUB_PASSWORD'"' '"'$RELEASE_USERNAME'"' '"'$RELEASE_PASSWORD'"' '"'$RELEASE'"' '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
 }
 
 node() {
@@ -14,7 +14,6 @@ node() {
   CI_JOB_ID=$6
   GITHUB_TOKEN=$7
   CI_COMMIT_REF_NAME=$8
-  WAIT=$9
 
   job_id=$(echo $CI_JOB_ID)
   gittoken=$(echo "$GITHUB_TOKEN")
@@ -63,8 +62,8 @@ node() {
   kubectl get pod
 
   # Add manual sleep of 9min
-  echo -e "\n Manual wait of $WAIT seconds for  director components to get deployed"
-  sleep $WAIT
+  echo -e "\n Manual wait for director components to get deployed"
+  sleep 600
 
   #Run Components health check
   echo -e "\n************************ Running basic-sanity tests ***********************************\n"
@@ -92,7 +91,7 @@ node() {
 }
 
 if [ "$1" == "node" ];then
-  node $2 $3 $4 $5 $6 $7 $8 $9 ${10}
+  node $2 $3 $4 $5 $6 $7 $8 $9
 else
   pod
 fi

--- a/stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP
+++ b/stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP
@@ -2,7 +2,7 @@
 
 pod() {
   echo "*************Deploying Director On-Prem*************"
-  sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP node '"'$GITHUB_USERNAME'"' '"'$GITHUB_PASSWORD'"' '"'$RELEASE_USERNAME'"' '"'$RELEASE_PASSWORD'"' '"'$RELEASE'"' '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"''
+  sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/infra-setup/TCID-DIR-INSTALL-ON-LOCAL-HP node '"'$GITHUB_USERNAME'"' '"'$GITHUB_PASSWORD'"' '"'$RELEASE_USERNAME'"' '"'$RELEASE_PASSWORD'"' '"'$RELEASE'"' '"'$CI_JOB_ID'"' '"'$GITHUB_TOKEN'"' '"'$CI_COMMIT_REF_NAME'"'' '"'$WAIT'"'
 }
 
 node() {
@@ -14,6 +14,7 @@ node() {
   CI_JOB_ID=$6
   GITHUB_TOKEN=$7
   CI_COMMIT_REF_NAME=$8
+  WAIT=$9
 
   job_id=$(echo $CI_JOB_ID)
   gittoken=$(echo "$GITHUB_TOKEN")
@@ -62,8 +63,8 @@ node() {
   kubectl get pod
 
   # Add manual sleep of 9min
-  echo -e "\n Manual wait for director components to get deployed"
-  sleep 600
+  echo -e "\n Manual wait of $WAIT seconds for  director components to get deployed"
+  sleep $WAIT
 
   #Run Components health check
   echo -e "\n************************ Running basic-sanity tests ***********************************\n"
@@ -91,7 +92,7 @@ node() {
 }
 
 if [ "$1" == "node" ];then
-  node $2 $3 $4 $5 $6
+  node $2 $3 $4 $5 $6 $7 $8 $9 ${10}
 else
   pod
 fi


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- This PR adds the localpv provisioning on selected blockdevice test in which block devices can be manually selected via block device tag specified in the storage class.
- Here we adding the test case in both the way positive and negative way, means for positive test case first we label the blockdevice and then verifies that volume is provisioned using only those bd's which have that label. On the other side for the negative test first we will provision the volume and then label the blockdevice. As because of bd tag constraint in storage class pvc will remain in pending state and after labeling the bd we will verify the reconciliation and checks if pvc gets bound