### PR TITLE
[skip ci]: skipping the xfs-clone job for zfslocalpv

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -402,11 +402,11 @@ TCID-ZFSPV-SNAPSHOT-CLONE-EXT4-CREATE:
     - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
     - ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
 
-TCID-ZFSPV-SNAPSHOT-CLONE-XFS-CREATE:
-  extends: .func_test_template
-  script:
-    - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
-    - ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+# TCID-ZFSPV-SNAPSHOT-CLONE-XFS-CREATE:
+#   extends: .func_test_template
+#   script:
+#     - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+#     - ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
 
 TCID-ZFS-VOL-RESIZE-ZFS:
   extends: .func_test_template


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- Due to this issue < https://github.com/openebs/zfs-localpv/issues/182  > this job keeps failing in pipeline. and the fix for this issue < https://github.com/openebs/zfs-localpv/pull/183 > merged after openebs 1.12.0-ee-RC1. So this changes are not reflecting in RC1 images. 
- This PR comments out this job for gitlab-ci yaml file to not execute in pipeline till this fix comes in -ee images.