### PR TITLE
[skip ci]: Enable xfs-clone test for zfspv in konvoy pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -414,11 +414,11 @@ TCID-ZFSPV-SNAPSHOT-CLONE-EXT4-CREATE:
     - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
     - ./stages/functional/ZFSPV-snapshot-clone-ext4/ZFSPV-snapshot-clone-ext4
 
-# TCID-ZFSPV-SNAPSHOT-CLONE-XFS-CREATE:
-#   extends: .func_test_template
-#   script:
-#     - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
-#     - ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+TCID-ZFSPV-SNAPSHOT-CLONE-XFS-CREATE:
+  extends: .func_test_template
+  script:
+    - chmod 755 ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
+    - ./stages/functional/ZFSPV-snapshot-clone-xfs/ZFSPV-snapshot-clone-xfs
 
 TCID-ZFS-VOL-RESIZE-ZFS:
   extends: .func_test_template


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- we disable this job when pipelines were running with 0.9.0-ee-RC1 images, as it was failing with this image. Fix has been done in final build of 0.9.0-ee image.

- So enabling this job again in konvoy pipeline.