### PR TITLE
Add(scripts): Included target network delay and cstor pool kill test scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -495,6 +495,18 @@ TCID-CSTOR-TARGET-KILL:
     - chmod 755 ./stages/chaos/cstor-Target-kill/target-kill
     - ./stages/chaos/cstor-Target-kill/target-kill
 
+TCID-CSTOR-TARGET-NETWORK-DELAY:
+  extends: .chaos_test_template
+  script:
+    - chmod 755 ./stages/chaos/cstor-Target-network-delay/target-network-delay
+    - ./stages/chaos/cstor-Target-network-delay/target-network-delay
+
+TCID-CSTOR-POOL-CONTAINER-FAILURE:
+  extends: .chaos_test_template
+  script:
+    - chmod 755 ./stages/chaos/cstor-pool-kill/cstor-pool-kill
+    - ./stages/chaos/cstor-pool-kill/cstor-pool-kill
+
 # ## Director metrics check
 # metrics-check:
 #   image: mayadataio/tools:gitlab-job-v5

--- a/stages/chaos/cstor-Target-network-delay/target-network-delay
+++ b/stages/chaos/cstor-Target-network-delay/target-network-delay
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/chaos/cstor-Target-network-delay/target-network-delay node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/config_c2
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+releaseTag=$(echo $4)
+case_id=ACME
+
+time="date"
+current_time=$(eval $time)
+
+present_dir=$(pwd)
+echo $present_dir
+
+bash utils/e2e-cr-new jobname:csi-target-network-delay jobphase:Waiting
+bash utils/e2e-cr-new jobname:csi-target-network-delay jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+
+################
+# LitmusBook 1 #
+################
+
+echo "*******Deploying percona Application****"
+
+run_id="network-delay";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+
+cp apps/percona/deployers/run_litmus_test.yml percona_target_network_delay.yml
+
+sed -i -e 's/app: percona-deployment/app: deploy-percona-target-nw-delay/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-nw-delay-/g' \
+-e 's/value: openebs-standard/value: openebs-cstor-csi/g' \
+-e 's/value: app-percona-ns/value: percona-target-nw-delay/g' percona_target_network_delay.yml
+
+sed -i '/name: TARGET_AFFINITY_CHECK/{n;s/.*/            value: /g}' percona_target_network_delay.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_target_network_delay.yml
+
+cat percona_target_network_delay.yml
+
+bash ../utils/litmus_job_runner label='app:deploy-percona-target-nw-delay' job=percona_target_network_delay.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:csi-target-network-delay $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 2 #
+################
+
+run_id="target-nw-delay";test_name=$(bash utils/generate_test_name testcase=percona-loadgen metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+cp apps/percona/workload/run_litmus_test.yml percona_loadgen_target_nw_delay.yml
+
+# Update the environmental variables in litmus job spec.
+
+sed -i -e 's/value: app-percona-ns/value: percona-target-nw-delay/g' \
+-e 's/generateName: percona-loadgen-/generateName: percona-loadgen-nw-delay-/g' \
+-e 's/loadgen: percona-loadjob/loadgen: percona-loadjob-nw-delay/g' percona_loadgen_target_nw_delay.yml
+
+cat percona_loadgen_target_nw_delay.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_loadgen_target_nw_delay.yml
+
+# Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='loadgen:percona-loadjob-nw-delay' job=percona_loadgen_target_nw_delay.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+# Update the e2e event for the job.
+bash utils/event_updater jobname:csi-target-network-delay $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 3 #
+################
+
+echo "*******Performing Network delay on target**********"
+
+test_name=$(bash utils/generate_test_name testcase=openebs-target-network-delay metadata="")
+echo $test_name
+
+cd e2e-tests
+cp experiments/chaos/openebs_target_network_delay/run_litmus_test.yml run_target_nw_delay_test.yml
+
+sed -i -e 's/value: app-percona-ns/value: percona-target-nw-delay/g' \
+-e 's/name: target-network-delay/name: csi-target-network-delay-config/g' \
+-e 's/name: openebs-target-network-delay/name: openebs-csi-target-network-delay/g' \
+-e 's/value: docker/value: containerd/g' run_target_nw_delay_test.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: mysql/}' run_target_nw_delay_test.yml
+
+## Insert the set of variables for percona data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    dbuser: root\
+    dbpassword: k8sDem0\
+    dbname: targetnetworkdelay
+' run_target_nw_delay_test.yml
+
+cat run_target_nw_delay_test.yml
+
+bash ../utils/litmus_job_runner label='name:openebs-csi-target-network-delay' job=run_target_nw_delay_test.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:csi-target-network-delay $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 4 #
+################
+ 
+kubectl delete job --all -n percona-target-nw-delay 
+
+echo "********Deprovisioning Percona Application*******"
+
+run_id="deprovision-network-delay";test_name=$(bash utils/generate_test_name testcase=percona-deployment metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+cp apps/percona/deployers/run_litmus_test.yml percona_deprovision_target_network_delay.yml
+
+sed -i -e 's/app: percona-deployment/app: deprovision-percona-csi-target-nw-delay/g' \
+-e 's/generateName: litmus-percona-/generateName: litmus-percona-deprovision-nw-delay/g' \
+-e 's/value: openebs-standard/value: openebs-cstor-csi/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e 's/value: app-percona-ns/value: percona-target-nw-delay/g' percona_deprovision_target_network_delay.yml
+
+sed -i '/name: TARGET_AFFINITY_CHECK/{n;s/.*/            value: /g}' percona_deprovision_target_network_delay.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' percona_deprovision_target_network_delay.yml           
+
+echo "Running the litmus test for percona Deprovision.."
+cat percona_deprovision_target_network_delay.yml
+
+bash ../utils/litmus_job_runner label='app:deprovision-percona-csi-target-nw-delay' job=percona_deprovision_target_network_delay.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:csi-target-network-delay $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+current_time=$(eval $time)
+
+if [ "$rc_val" != "0" ]; then
+bash utils/e2e-cr-new jobname:csi-target-network-delay jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+exit 1;
+fi
+
+bash utils/e2e-cr-new jobname:csi-target-network-delay jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4 $5
+else
+  pod
+fi

--- a/stages/chaos/cstor-pool-kill/cstor-pool-kill
+++ b/stages/chaos/cstor-pool-kill/cstor-pool-kill
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd oep-e2e-konvoy && bash stages/chaos/cstor-pool-kill/cstor-pool-kill node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
+}
+
+node() {
+
+export KUBECONFIG=~/.kube/config_c2	
+
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+releaseTag=$(echo $4)
+case_id=ZCCC
+
+time="date"
+current_time=$(eval $time)
+
+present_dir=$(pwd)
+echo $present_dir
+bash utils/e2e-cr-new jobname:cspc-cstor-pool-kill jobphase:Waiting
+bash utils/e2e-cr-new jobname:cspc-cstor-pool-kill jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
+
+################
+# LitmusBook 1 #
+################
+
+echo "*******Deploying Busybox Application****"
+
+test_name=$(bash utils/generate_test_name testcase=busybox-provision-cstor-pool-kill metadata="")
+echo $test_name
+
+cd e2e-tests
+echo "Running the litmus test for Busybox Deployment.."
+
+cp apps/busybox/deployers/run_litmus_test.yml busybox_cstor_pool_kill.yml
+
+sed -i -e 's/app: busybox-litmus/app: deploy-busybox-cstor-pool-kill/g' \
+-e 's/app=busybox-sts/app=cstor-pool-kill/g' \
+-e 's/value: statefulset/value: deployment/g' \
+-e 's/value: openebs-cstor-sparse/value: openebs-cstor-csi/g' \
+-e 's/value: openebs-busybox/value: openebs-bb-poolkill/g' \
+-e 's/value: app-busybox-ns/value: cstor-pool-kill/g' busybox_cstor_pool_kill.yml
+cat busybox_cstor_pool_kill.yml
+
+bash ../utils/litmus_job_runner label='app:deploy-busybox-cstor-pool-kill' job=busybox_cstor_pool_kill.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:cspc-cstor-pool-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 2 #
+################
+
+run_id="cstor-pool-kill";test_name=$(bash utils/generate_test_name testcase=busybox-liveness metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+# copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/busybox/liveness/run_litmus_test.yml busybox_loadgen_cstor_pool_kill.yml
+
+sed -i -e 's/value: app-busybox-ns/value: cstor-pool-kill/g' \
+-e 's/app=busybox-sts/app=cstor-pool-kill/g' \
+-e 's/liveness: litmus-busybox-liveness/liveness: busybox-liveness-cstor-pool-kill/g' busybox_loadgen_cstor_pool_kill.yml
+
+cat busybox_loadgen_cstor_pool_kill.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' busybox_loadgen_cstor_pool_kill.yml
+
+# Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='liveness:busybox-liveness-cstor-pool-kill' job=busybox_loadgen_cstor_pool_kill.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+# Update the e2e event for the job.
+bash utils/event_updater jobname:cspc-cstor-pool-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 3 #
+################
+
+echo "*******Performing CSPC cStor Pool kill**********"
+
+test_name=$(bash utils/generate_test_name testcase=cspc-pool-failure metadata="")
+echo $test_name
+
+cd e2e-tests
+cp experiments/chaos/cspc_pool_failure/container_failure/run_litmus_test.yml cspc-poolkill.yml
+
+sed -i -e '/name: APP_NAMESPACE/{n;s/.*/            value: cstor-pool-kill/g}' \
+-e '/name: APP_LABEL/{n;s/.*/            value: app=cstor-pool-kill/g}' \
+-e '/name: APP_PVC/{n;s/.*/            value: openebs-bb-poolkill/g}' \
+-e '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' cspc-poolkill.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: cspcpoolkill
+' cspc-poolkill.yml
+
+cat cspc-poolkill.yml
+
+bash ../utils/litmus_job_runner label='name:cspc-pool-failure' job=cspc-poolkill.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:cspc-cstor-pool-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 4 #
+################
+
+run_id="deprovision-cstor-pool-kill";test_name=$(bash utils/generate_test_name testcase=busybox-liveness metadata=${run_id})
+echo $test_name
+
+cd e2e-tests
+# copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.
+cp apps/busybox/liveness/run_litmus_test.yml busybox_loadgen_deprovision_cstor_pool_kill.yml
+
+# Update the environmental variables in litmus job spec.
+
+sed -i -e 's/value: app-busybox-ns/value: cstor-pool-kill/g' \
+-e 's/app=busybox-sts/app=cstor-pool-kill/g' \
+-e 's/value: provision/value: deprovision/g' \
+-e 's/liveness: litmus-busybox-liveness/liveness: busybox-liveness-deprovision-cstor-pool-kill/g' busybox_loadgen_deprovision_cstor_pool_kill.yml
+
+sed -i '/command:/i \
+          - name: RUN_ID\
+            value: '"$run_id"'\
+' busybox_loadgen_deprovision_cstor_pool_kill.yml
+
+cat busybox_loadgen_deprovision_cstor_pool_kill.yml
+# Run the Litmus job and get the details of the litmus job from litmus_job_runner utils.
+bash ../utils/litmus_job_runner label='liveness:busybox-liveness-deprovision-cstor-pool-kill' job=busybox_loadgen_deprovision_cstor_pool_kill.yml
+cd ..
+# Get the cluster state Once the litmus jobs completed.
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:cspc-cstor-pool-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+
+# Update result of the test case in github mayadata-io/e2e-openshift repository.
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+
+################
+# LitmusBook 5 #
+################
+
+echo "********Deprovisioning Busybox Application*******"
+
+test_name=$(bash utils/generate_test_name testcase=busybox-deprovision-cstor-pool-kill metadata="")
+echo $test_name
+
+cd e2e-tests
+cp apps/busybox/deployers/run_litmus_test.yml deprovision_cstor_pool_kill.yml
+
+sed -i -e 's/generateName: litmus-busybox-deploy/generateName: busybox-deprovision-cstor-pool-kill/g' \
+-e 's/app: busybox-litmus/app: busybox-deprovision-cstor-pool-kill/g' \
+-e 's/app=busybox-sts/app=cstor-pool-kill/g' \
+-e 's/value: statefulset/value: deployment/g' \
+-e 's/value: openebs-cstor-sparse/value: openebs-cstor-disk/g' \
+-e 's/value: openebs-busybox/value: openebs-bb-poolkill/g' \
+-e 's/value: app-busybox-ns/value: cstor-pool-kill/g' \
+-e 's/value: provision/value: deprovision/g' deprovision_cstor_pool_kill.yml
+
+cat deprovision_cstor_pool_kill.yml
+
+bash ../utils/litmus_job_runner label='app:busybox-deprovision-cstor-pool-kill' job=deprovision_cstor_pool_kill.yml
+cd ..
+bash utils/dump_cluster_state;
+bash utils/event_updater jobname:cspc-cstor-pool-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+rc_val=$(echo $?)
+current_time=$(eval $time)
+
+if [ "$rc_val" != "0" ]; then
+bash utils/e2e-cr-new jobname:cspc-cstor-pool-kill jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Fail
+exit 1;
+fi
+
+bash utils/e2e-cr-new jobname:cspc-cstor-pool-kill jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag" test_result:Pass
+
+if [ "$rc_val" != "0" ]; then
+exit 1;
+fi
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4 $5
+else
+  pod
+fi


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- This PR includes the test scripts for cstor target network delay and csto pool kill test into pipeline
- For cstor target network delay the flow is 
  - deploying percona application ==> create loadgen ==> perform network delay on istgt container and verify the application/volume status == > deprovision the application
- for cstor pool kill test the flow is
   - deploying busybox application ==> create liveness ==> perfroming cspc pool kill and check the volume and app status ==> deprovision the liveness ==> deprovision the application