### PR TITLE
[skip ci]: removed the os dependecy from sed command

### DIFF
--- a/stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
+++ b/stages/functional/ZFS-LocalPV-provisioner/ZFS-LocalPV-provisioner
@@ -51,7 +51,6 @@ cp experiments/zfs-localpv/zfs-localpv-provisioner/run_litmus_test.yml zfs_pv_pr
 sed -i -e '/name: STORAGE_CLASS/{n;s/.*/            value: zfs-sc/g}' \
 -e "/name: ZFS_BRANCH/{n;s/.*/            value: ${zfs_branch}/g}" \
 -e "/name: ZFS_DRIVER_IMAGE/{n;s/.*/            value: ${zfs_driver_image}/g}" \
--e '/name: OS_NAME/{n;s/.*/            value: centos7/g}' \
 -e '/name: ZPOOL_CREATION/{n;s/.*/            value: "false"/g}' \
 -e '/name: POOL_NAME/{n;s/.*/            value: zfs-test-pool/g}' \
 -e '/name: POOL_TYPE/{n;s/.*/            value: striped/g}' \


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

- To accommodate the changes done this [PR](https://github.com/openebs/e2e-tests/pull/516) , modified the sed command to remove the OS dependency env.